### PR TITLE
Improved string conversion and a workaround for an absurd byondapi bug.

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -3,7 +3,7 @@ use crate::byond;
 use std::{
 	borrow::Cow,
 	convert::Infallible,
-	ffi::{CStr, CString, FromBytesWithNulError, IntoStringError, NulError},
+	ffi::{CStr, CString, FromBytesUntilNulError, IntoStringError, NulError},
 	str::Utf8Error,
 };
 
@@ -81,9 +81,9 @@ impl From<Utf8Error> for ByondError {
 	}
 }
 
-impl From<FromBytesWithNulError> for ByondError {
+impl From<FromBytesUntilNulError> for ByondError {
 	#[inline]
-	fn from(_: FromBytesWithNulError) -> Self {
+	fn from(_: FromBytesUntilNulError) -> Self {
 		Self::NonUtf8String
 	}
 }

--- a/crates/core/src/from/string.rs
+++ b/crates/core/src/from/string.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: 0BSD
-use crate::{ByondError, ByondResult, ByondValue, FromByond};
-use std::{ffi::CString, path::PathBuf};
+use crate::{ByondResult, ByondValue, FromByond};
+use std::{
+	ffi::{CStr, CString},
+	path::PathBuf,
+};
 
 impl FromByond for CString {
 	#[inline]
 	fn from_byond(value: &ByondValue) -> ByondResult<Self> {
-		value
-			.get_string()
-			.and_then(|s| CString::new(s).map_err(|_| ByondError::NonUtf8String))
+		Ok(CStr::from_bytes_until_nul(value.get_string_bytes()?.as_slice())?.to_owned())
 	}
 }
 

--- a/crates/core/src/to/string.rs
+++ b/crates/core/src/to/string.rs
@@ -23,9 +23,7 @@ impl ToByond for String {
 impl ToByond for &CStr {
 	#[inline]
 	fn to_byond(&self) -> ByondResult<ByondValue> {
-		self.to_str()
-			.map_err(|_| ByondError::NonUtf8String)
-			.map(ByondValue::new_string)
+		Ok(ByondValue::new_string(self.to_bytes()))
 	}
 }
 


### PR DESCRIPTION
Byond strings are `CString`s. `CString`s cannot contain interior nulls, but can otherwise be an arbitrary sequence of bytes. Rust `String`s cannot contain invalid UTF-8 sequences, but can contain interior nulls.

As a result of these characteristics, neither `CString`s nor `String`s are a superset of the other.

Because of this, I have moved most of `ByondValue::get_string` to a function that instead returns a `Vec<u8>`, which can then be converted into either a `CString` or a `String`. `ByondValue::new_string` has also been modified to accept any type that can be converted into a `Vec<u8>`.

The other change I made addresses a byondapi bug that I only got to happen on tgstation code, in which `Byond_ToString` sets the `buf_len` output parameter to value greater than the actual length of the string, leading to the buffer containing an interior null followed by garbage data.

Fortunately, `CString::from_bytes_until_null` comes to the rescue. If the bug works exactly how I think it does, the buffer will only ever be too long for the valid string. As such, we can use the aforementioned function to get only the valid string, with none of the garbage or interior nulls.